### PR TITLE
[FIX] changed text and icon color to dynamic

### DIFF
--- a/src/components/single-art-page/comment/Comment.tsx
+++ b/src/components/single-art-page/comment/Comment.tsx
@@ -198,9 +198,9 @@ export default function Comment(props: IChildCommentProps | IParentCommentProps)
                   onClick={handleReply}
                   disabled={replyMessage.trim() === ""}
                   className={cn(
-                    "text-white font-semibold px-4 py-2 rounded",
-                    replyMessage.trim() === "" ? "bg-gray-400 cursor-not-allowed" : "bg-primary"
-                  )}
+                    "text-tertiary font-semibold px-4 py-2 rounded",
+                    replyMessage.trim() === "" ? "bg-secondary cursor-not-allowed" : "bg-primary"
+                  )}  
                 >
                   Répondre
                 </button>
@@ -220,7 +220,7 @@ export default function Comment(props: IChildCommentProps | IParentCommentProps)
           <div className={cn("self-start flex gap-2", props.isChild ? "ml-24" : "ml-14")}>
             <IconButton
               icon={isCommentLiked ? ThumbUp : ThumbUpOutlined}
-              iconColor="black"
+              iconColor="tertiary"
               onClick={onLikeComment}
               text={props.comment.likes.length.toString()}
               className="flex gap-2 px-2 py-1 items-center"
@@ -229,7 +229,7 @@ export default function Comment(props: IChildCommentProps | IParentCommentProps)
             />
             <button
               onClick={() => setIsReplyingTo(props.comment.userId)}
-              className="text-black text-sm px-4 py-2 rounded-2xl hover:bg-background-inputfield"
+              className="text-tertiary text-sm px-4 py-2 rounded-2xl hover:bg-background-inputfield"
             >
               Répondre
             </button>


### PR DESCRIPTION
J'ai modifier la section réponse dans le chat des œuvres pour s'adapter au thème sombre. (Les valeurs étaient des couleurs en dur). Le texte entré par l'utilisateur pour répondre a déjà été corrigé dans une autre pull request en préparation.