### PR TITLE
[ADD] mobile redirections

### DIFF
--- a/src/app/mobile/canceled/page.tsx
+++ b/src/app/mobile/canceled/page.tsx
@@ -1,0 +1,5 @@
+import PaymentCanceledWrapper from "../../../wrappers/mobile/PaymentCanceledWrapper";
+
+export default function Page(): JSX.Element {
+  return <PaymentCanceledWrapper />;
+}

--- a/src/app/mobile/stripe/page.tsx
+++ b/src/app/mobile/stripe/page.tsx
@@ -1,0 +1,6 @@
+import StripeLinkedWrapper from "../../../wrappers/mobile/StripeLinkedWrapper";
+
+export default function Page(): JSX.Element {
+  return <StripeLinkedWrapper />;
+}
+

--- a/src/app/mobile/success/page.tsx
+++ b/src/app/mobile/success/page.tsx
@@ -1,0 +1,5 @@
+import PaymentSuccessWrapper from "../../../wrappers/mobile/PaymentSuccessWrapper";
+
+export default function Page(): JSX.Element {
+  return <PaymentSuccessWrapper />;
+}

--- a/src/app/tabs.ts
+++ b/src/app/tabs.ts
@@ -137,6 +137,14 @@ const tabs: ITab[] = [
     verticalNavbar: true,
     header: true,
   },
+  {
+   name: 'Mobile',
+   href: '/mobile',
+   loggedIn: false,
+   navbar: false,
+   verticalNavbar: false,
+   header: false,
+  }
 ];
 
 export default tabs;

--- a/src/wrappers/mobile/PaymentCanceledWrapper.tsx
+++ b/src/wrappers/mobile/PaymentCanceledWrapper.tsx
@@ -7,14 +7,9 @@ export default function PaymentCanceledWrapper(): JSX.Element {
 
   return (
     <div className="bg-slate-50 py-4 px-6 flex flex-col items-center w-[90%] m-auto shadow-md rounded-2xl">
-      <span className="text-black mb-4">
-        Le paiement a échoué...
-      </span>
-      <button
-        onClick={handleClick}
-        className="bg-primary text-white py-2 px-6 text-lg cursor-pointer rounded-lg"
-      >
-        Retourner à l'application
+      <span className="text-black mb-4">Le paiement a échoué...</span>
+      <button onClick={handleClick} className="bg-primary text-white py-2 px-6 text-lg cursor-pointer rounded-lg">
+        Retourner à l&apos;application
       </button>
     </div>
   );

--- a/src/wrappers/mobile/PaymentCanceledWrapper.tsx
+++ b/src/wrappers/mobile/PaymentCanceledWrapper.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+export default function PaymentCanceledWrapper(): JSX.Element {
+  const handleClick = () => {
+    window.open("myapp://payment-canceled", "_blank");
+  };
+
+  return (
+    <div className="bg-slate-50 py-4 px-6 flex flex-col items-center w-[90%] m-auto shadow-md rounded-2xl">
+      <span className="text-black mb-4">
+        Le paiement a échoué...
+      </span>
+      <button
+        onClick={handleClick}
+        className="bg-primary text-white py-2 px-6 text-lg cursor-pointer rounded-lg"
+      >
+        Retourner à l'application
+      </button>
+    </div>
+  );
+}

--- a/src/wrappers/mobile/PaymentSuccessWrapper.tsx
+++ b/src/wrappers/mobile/PaymentSuccessWrapper.tsx
@@ -7,14 +7,9 @@ export default function PaymentSuccessWrapper(): JSX.Element {
 
   return (
     <div className="bg-slate-50 py-4 px-6 flex flex-col items-center w-[90%] m-auto shadow-md rounded-2xl">
-      <span className="text-black mb-4">
-        Le paiement est réussi !
-      </span>
-      <button
-        onClick={handleClick}
-        className="bg-primary text-white py-2 px-6 text-lg cursor-pointer rounded-lg"
-      >
-        Retourner à l'application
+      <span className="text-black mb-4">Le paiement est réussi !</span>
+      <button onClick={handleClick} className="bg-primary text-white py-2 px-6 text-lg cursor-pointer rounded-lg">
+        Retourner à l&apos;application
       </button>
     </div>
   );

--- a/src/wrappers/mobile/PaymentSuccessWrapper.tsx
+++ b/src/wrappers/mobile/PaymentSuccessWrapper.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+export default function PaymentSuccessWrapper(): JSX.Element {
+  const handleClick = () => {
+    window.open("myapp://payment-success", "_blank");
+  };
+
+  return (
+    <div className="bg-slate-50 py-4 px-6 flex flex-col items-center w-[90%] m-auto shadow-md rounded-2xl">
+      <span className="text-black mb-4">
+        Le paiement est réussi !
+      </span>
+      <button
+        onClick={handleClick}
+        className="bg-primary text-white py-2 px-6 text-lg cursor-pointer rounded-lg"
+      >
+        Retourner à l'application
+      </button>
+    </div>
+  );
+}

--- a/src/wrappers/mobile/StripeLinkedWrapper.tsx
+++ b/src/wrappers/mobile/StripeLinkedWrapper.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+export default function StripeLinkedWrapper(): JSX.Element {
+  const handleClick = () => {
+    window.open("myapp://stripe-linked", "_blank");
+  };
+
+  return (
+    <div className="bg-slate-50 py-4 px-6 flex flex-col items-center w-[90%] m-auto shadow-md rounded-2xl">
+      <span className="text-black mb-4">
+        Votre compte de paiement a été lié avec votre application Leon'art !
+      </span>
+      <button
+        onClick={handleClick}
+        className="bg-primary text-white py-2 px-6 text-lg cursor-pointer rounded-lg"
+      >
+        Retourner à l'application
+      </button>
+    </div>
+  );
+}

--- a/src/wrappers/mobile/StripeLinkedWrapper.tsx
+++ b/src/wrappers/mobile/StripeLinkedWrapper.tsx
@@ -7,14 +7,9 @@ export default function StripeLinkedWrapper(): JSX.Element {
 
   return (
     <div className="bg-slate-50 py-4 px-6 flex flex-col items-center w-[90%] m-auto shadow-md rounded-2xl">
-      <span className="text-black mb-4">
-        Votre compte de paiement a été lié avec votre application Leon'art !
-      </span>
-      <button
-        onClick={handleClick}
-        className="bg-primary text-white py-2 px-6 text-lg cursor-pointer rounded-lg"
-      >
-        Retourner à l'application
+      <span className="text-black mb-4">Votre compte de paiement a été lié avec votre application Leon&apos;art !</span>
+      <button onClick={handleClick} className="bg-primary text-white py-2 px-6 text-lg cursor-pointer rounded-lg">
+        Retourner à l&apos;application
       </button>
     </div>
   );


### PR DESCRIPTION
In this PR, I added routes that are necessary for stripe redirections on the mobile app. I worked with @MariusNWK on this one, so if you have any other questions, do not hesitate to ask him.

I added three routes under `/mobile`:  
- `/mobile/success`: when an order payment was successful,  
- `/mobile/canceled`: when an order payment was canceled or failed,  
- `/mobile/stripe`: when an account was successfully linked to the database